### PR TITLE
Add Wally.toml file

### DIFF
--- a/aftman.toml
+++ b/aftman.toml
@@ -4,4 +4,5 @@
 # To add a new tool, add an entry to this table.
 [tools]
 rojo = "rojo-rbx/rojo@7.3.0"
+wally = "UpliftGames/wally@0.3.2"
 # rojo = "rojo-rbx/rojo@6.2.0"

--- a/build.project.json
+++ b/build.project.json
@@ -1,0 +1,13 @@
+{
+  "name": "Ceive-ImGizmo",
+  "tree": {
+    "$className": "DataModel",
+
+    "ReplicatedStorage": {
+      "Gizmo": {
+        "$path": "src/CeiveImGizmo"
+      }
+    }
+
+  }
+}

--- a/default.project.json
+++ b/default.project.json
@@ -1,6 +1,6 @@
 {
     "name": "imgizmo",
     "tree": {
-        "$path": "src"
+        "$path": "src/CeiveImGizmo"
     }
 }

--- a/default.project.json
+++ b/default.project.json
@@ -1,13 +1,6 @@
 {
-  "name": "Ceive-ImGizmo",
-  "tree": {
-    "$className": "DataModel",
-
-    "ReplicatedStorage": {
-      "Gizmo": {
-        "$path": "src/CeiveImGizmo"
-      }
+    "name": "imgizmo",
+    "tree": {
+        "$path": "src"
     }
-
-  }
 }

--- a/wally.toml
+++ b/wally.toml
@@ -1,6 +1,6 @@
 [package]
 name = "JakeyWasTaken/imgizmo"
-version = "3.2.0"
+version = "3.2.1"
 registry = "https://github.com/UpliftGames/wally-index"
 realm = "shared"
 

--- a/wally.toml
+++ b/wally.toml
@@ -1,0 +1,7 @@
+[package]
+name = "JakeyWasTaken/imgizmo"
+version = "3.2.0"
+registry = "https://github.com/UpliftGames/wally-index"
+realm = "shared"
+
+[dependencies]

--- a/wally.toml
+++ b/wally.toml
@@ -1,6 +1,6 @@
 [package]
 name = "JakeyWasTaken/imgizmo"
-version = "3.2.1"
+version = "3.2.2"
 registry = "https://github.com/UpliftGames/wally-index"
 realm = "shared"
 


### PR DESCRIPTION
This PR adds a `wally.toml` file to the project so that it can be published onto Wally. Once the PR is merged, you'll have to `aftman install` in the project directory and then run `wally publish` to publish the package under your scope.

In the meantime, I also published my fork under `grilme99/imgizmo@3.2.0`.