### PR TITLE
Various fixes to how table.remove() is used

### DIFF
--- a/src/CeiveImGizmo/init.lua
+++ b/src/CeiveImGizmo/init.lua
@@ -545,24 +545,24 @@ function Ceive.TweenProperties(Properties: {}, Goal: {}, TweenInfo: TweenInfo): 
 	local p_Properties = Properties
 	local c_Properties = deepCopy(Properties)
 
-	table.insert(Tweens, {
+	local Tween = {
 		p_Properties = p_Properties,
 		Properties = c_Properties,
 		Goal = Goal,
 		TweenInfo = TweenInfo,
 		Time = 0,
-	})
+	}
 
-	local TweenIndex = #Tweens
+	Tweens[Tween] = true
 
 	return function()
-		table.remove(Tweens, TweenIndex)
+		Tweens[Tween] = nil
 	end
 end
 
 function Ceive.Init()
 	RunService.RenderStepped:Connect(function(dt)
-		for i, Tween in Tweens do
+		for Tween in Tweens do
 			Tween.Time += dt
 			local Alpha = Tween.Time / Tween.TweenInfo.Time
 
@@ -590,7 +590,7 @@ function Ceive.Init()
 			end
 
 			if Alpha == 1 then
-				table.remove(Tweens, i)
+				Tweens[Tween] = nil
 			end
 		end
 

--- a/src/CeiveImGizmo/init.lua
+++ b/src/CeiveImGizmo/init.lua
@@ -594,7 +594,8 @@ function Ceive.Init()
 			end
 		end
 
-		for i, DebrisObject in Debris do
+		for i = #Debris, 1, -1 do
+			local DebrisObject = Debris[i]
 			local DebrisType = DebrisObject[1]
 			local DebrisLifetime = DebrisObject[2]
 			local DebrisBirth = DebrisObject[3]
@@ -621,7 +622,8 @@ function Ceive.Init()
 			DebrisCallback()
 		end
 
-		for i, Gizmo in RetainObjects do
+		for i = #RetainObjects, 1, -1 do
+			local Gizmo = RetainObjects[i]
 			local GizmoPropertys = Gizmo[2]
 
 			if not GizmoPropertys.Enabled then

--- a/src/CeiveImGizmo/init.lua
+++ b/src/CeiveImGizmo/init.lua
@@ -61,12 +61,13 @@ end
 local function Request(ClassName)
 	if not Pool[ClassName] then
 		return Instance.new(ClassName)
-	elseif not Pool[ClassName][1] then
-		return Instance.new(ClassName)
 	end
 
-	local Object = Pool[ClassName][1]
-	table.remove(Pool[ClassName], 1)
+	local Object = table.remove(Pool[ClassName])
+
+	if not Object then
+		return Instance.new(ClassName)
+	end
 
 	return Object
 end


### PR DESCRIPTION
Hello!

I'm looking into using your library, so I went and reviewed the code a bit.

I noticed a couple of bugs, mostly coming from the usage and consequences of `table.remove()`.

1. `Request()` was removing the first element of the object pool. This is inefficient because it shifts all the other elements back by one, which is the worst case for performance. I changed it to remove the last element of the pool instead, so it's a constant time operation now.

2. The tween cancellation function returned from `TweenProperties()` was using a potentially outdated index from the past. 
    1. Tweens: `{ A, B, C }` <- Indexes are correct here
    2. Remove tween B at index 2
    3. Tweens: `{ A, C }` <- Index for C is now incorrect
    4. Remove tween C at index 3, but index 3 doesn't exist anymore

3. There were some places where a table was iterated, and some elements were removed in the middle. This caused one element to be skipped every time one gets removed, because the element at the next index gets shifted into the current one. The simplest fix for this is to reverse iteration order.
    