### PR TITLE
Make PropertyTable.Destroy into a function

### DIFF
--- a/src/CeiveImGizmo/Gizmos/Arrow.lua
+++ b/src/CeiveImGizmo/Gizmos/Arrow.lua
@@ -56,10 +56,9 @@ function Gizmo:Create(Origin: Vector3, End: Vector3, Radius: number, Length: num
 		Transparency = self.Propertys.Transparency,
 		Color3 = self.Propertys.Color3,
 		Enabled = true,
-		Destroy = false,
 	}
 
-	self.Retain(self, PropertyTable)
+	PropertyTable.Destroy = self.Retain(self, PropertyTable)
 
 	return PropertyTable
 end

--- a/src/CeiveImGizmo/Gizmos/Box.lua
+++ b/src/CeiveImGizmo/Gizmos/Box.lua
@@ -112,10 +112,9 @@ function Gizmo:Create(Transform: CFrame, Size: Vector3, DrawTriangles: boolean)
 		Transparency = self.Propertys.Transparency,
 		Color3 = self.Propertys.Color3,
 		Enabled = true,
-		Destroy = false,
 	}
 
-	self.Retain(self, PropertyTable)
+	PropertyTable.Destroy = self.Retain(self, PropertyTable)
 
 	return PropertyTable
 end

--- a/src/CeiveImGizmo/Gizmos/Capsule.lua
+++ b/src/CeiveImGizmo/Gizmos/Capsule.lua
@@ -98,10 +98,9 @@ function Gizmo:Create(Transform: CFrame, Radius: number, Length: number, Subdivi
 		Transparency = self.Propertys.Transparency,
 		Color3 = self.Propertys.Color3,
 		Enabled = true,
-		Destroy = false,
 	}
 
-	self.Retain(self, PropertyTable)
+	PropertyTable.Destroy = self.Retain(self, PropertyTable)
 
 	return PropertyTable
 end

--- a/src/CeiveImGizmo/Gizmos/Circle.lua
+++ b/src/CeiveImGizmo/Gizmos/Circle.lua
@@ -89,10 +89,9 @@ function Gizmo:Create(Transform: CFrame, Radius: number, Subdivisions: number, A
 		Transparency = self.Propertys.Transparency,
 		Color3 = self.Propertys.Color3,
 		Enabled = true,
-		Destroy = false,
 	}
 
-	self.Retain(self, PropertyTable)
+	PropertyTable.Destroy = self.Retain(self, PropertyTable)
 
 	return PropertyTable
 end

--- a/src/CeiveImGizmo/Gizmos/Cone.lua
+++ b/src/CeiveImGizmo/Gizmos/Cone.lua
@@ -85,10 +85,9 @@ function Gizmo:Create(Transform: CFrame, Radius: number, Length: number, Subdivi
 		Transparency = self.Propertys.Transparency,
 		Color3 = self.Propertys.Color3,
 		Enabled = true,
-		Destroy = false,
 	}
 
-	self.Retain(self, PropertyTable)
+	PropertyTable.Destroy = self.Retain(self, PropertyTable)
 
 	return PropertyTable
 end

--- a/src/CeiveImGizmo/Gizmos/Cylinder.lua
+++ b/src/CeiveImGizmo/Gizmos/Cylinder.lua
@@ -93,10 +93,9 @@ function Gizmo:Create(Transform: CFrame, Radius: number, Length: number, Subdivi
 		Transparency = self.Propertys.Transparency,
 		Color3 = self.Propertys.Color3,
 		Enabled = true,
-		Destroy = false,
 	}
 
-	self.Retain(self, PropertyTable)
+	PropertyTable.Destroy = self.Retain(self, PropertyTable)
 
 	return PropertyTable
 end

--- a/src/CeiveImGizmo/Gizmos/Line.lua
+++ b/src/CeiveImGizmo/Gizmos/Line.lua
@@ -46,10 +46,9 @@ function Gizmo:Create(Transform: CFrame, Length: number)
 		Transparency = self.Propertys.Transparency,
 		Color3 = self.Propertys.Color3,
 		Enabled = true,
-		Destroy = false,
 	}
 	
-	self.Retain(self, PropertyTable)
+	PropertyTable.Destroy = self.Retain(self, PropertyTable)
 	
 	return PropertyTable
 end

--- a/src/CeiveImGizmo/Gizmos/Mesh.lua
+++ b/src/CeiveImGizmo/Gizmos/Mesh.lua
@@ -101,10 +101,9 @@ function Gizmo:Create(Transform: CFrame, Size: Vector3, Vertices, Faces)
 		Transparency = self.Propertys.Transparency,
 		Color3 = self.Propertys.Color3,
 		Enabled = true,
-		Destroy = false,
 	}
 
-	self.Retain(self, PropertyTable)
+	PropertyTable.Destroy = self.Retain(self, PropertyTable)
 
 	return PropertyTable
 end

--- a/src/CeiveImGizmo/Gizmos/Plane.lua
+++ b/src/CeiveImGizmo/Gizmos/Plane.lua
@@ -72,10 +72,9 @@ function Gizmo:Create(Position: Vector3, Normal: Vector3, Size: Vector3)
 		Transparency = self.Propertys.Transparency,
 		Color3 = self.Propertys.Color3,
 		Enabled = true,
-		Destroy = false,
 	}
 
-	self.Retain(self, PropertyTable)
+	PropertyTable.Destroy = self.Retain(self, PropertyTable)
 
 	return PropertyTable
 end

--- a/src/CeiveImGizmo/Gizmos/Ray.lua
+++ b/src/CeiveImGizmo/Gizmos/Ray.lua
@@ -50,10 +50,9 @@ function Gizmo:Create(Origin: Vector3, End: Vector3)
 		Transparency = self.Propertys.Transparency,
 		Color3 = self.Propertys.Color3,
 		Enabled = true,
-		Destroy = false,
 	}
 	
-	self.Retain(self, PropertyTable)
+	PropertyTable.Destroy = self.Retain(self, PropertyTable)
 	
 	return PropertyTable
 end

--- a/src/CeiveImGizmo/Gizmos/Sphere.lua
+++ b/src/CeiveImGizmo/Gizmos/Sphere.lua
@@ -52,10 +52,9 @@ function Gizmo:Create(Transform: CFrame, Radius: number, Subdivisions: number, A
 		Transparency = self.Propertys.Transparency,
 		Color3 = self.Propertys.Color3,
 		Enabled = true,
-		Destroy = false,
 	}
 
-	self.Retain(self, PropertyTable)
+	PropertyTable.Destroy = self.Retain(self, PropertyTable)
 
 	return PropertyTable
 end

--- a/src/CeiveImGizmo/Gizmos/VolumeArrow.lua
+++ b/src/CeiveImGizmo/Gizmos/VolumeArrow.lua
@@ -68,10 +68,9 @@ function Gizmo:Create(Origin: Vector3, End: Vector3, CylinderRadius: number, Con
 		Transparency = self.Propertys.Transparency,
 		Color3 = self.Propertys.Color3,
 		Enabled = true,
-		Destroy = false,
 	}
 
-	self.Retain(self, PropertyTable)
+	PropertyTable.Destroy = self.Retain(self, PropertyTable)
 
 	return PropertyTable
 end

--- a/src/CeiveImGizmo/Gizmos/VolumeBox.lua
+++ b/src/CeiveImGizmo/Gizmos/VolumeBox.lua
@@ -58,10 +58,9 @@ function Gizmo:Create(Transform: CFrame, Size: Vector3)
 		Transparency = self.Propertys.Transparency,
 		Color3 = self.Propertys.Color3,
 		Enabled = true,
-		Destroy = false,
 	}
 
-	self.Retain(self, PropertyTable)
+	PropertyTable.Destroy = self.Retain(self, PropertyTable)
 
 	return PropertyTable
 end

--- a/src/CeiveImGizmo/Gizmos/VolumeCone.lua
+++ b/src/CeiveImGizmo/Gizmos/VolumeCone.lua
@@ -62,10 +62,9 @@ function Gizmo:Create(Transform: CFrame, Radius: number, Length: number)
 		Transparency = self.Propertys.Transparency,
 		Color3 = self.Propertys.Color3,
 		Enabled = true,
-		Destroy = false,
 	}
 
-	self.Retain(self, PropertyTable)
+	PropertyTable.Destroy = self.Retain(self, PropertyTable)
 
 	return PropertyTable
 end

--- a/src/CeiveImGizmo/Gizmos/VolumeCylinder.lua
+++ b/src/CeiveImGizmo/Gizmos/VolumeCylinder.lua
@@ -70,10 +70,9 @@ function Gizmo:Create(Transform: CFrame, Radius: number, Length: number, InnerRa
 		Transparency = self.Propertys.Transparency,
 		Color3 = self.Propertys.Color3,
 		Enabled = true,
-		Destroy = false,
 	}
 
-	self.Retain(self, PropertyTable)
+	PropertyTable.Destroy = self.Retain(self, PropertyTable)
 
 	return PropertyTable
 end

--- a/src/CeiveImGizmo/Gizmos/VolumeSphere.lua
+++ b/src/CeiveImGizmo/Gizmos/VolumeSphere.lua
@@ -58,10 +58,9 @@ function Gizmo:Create(Transform: CFrame, Radius: number)
 		Transparency = self.Propertys.Transparency,
 		Color3 = self.Propertys.Color3,
 		Enabled = true,
-		Destroy = false,
 	}
 
-	self.Retain(self, PropertyTable)
+	PropertyTable.Destroy = self.Retain(self, PropertyTable)
 
 	return PropertyTable
 end

--- a/src/CeiveImGizmo/Gizmos/Wedge.lua
+++ b/src/CeiveImGizmo/Gizmos/Wedge.lua
@@ -108,10 +108,9 @@ function Gizmo:Create(Transform: CFrame, Size: Vector3, DrawTriangles: boolean)
 		Transparency = self.Propertys.Transparency,
 		Color3 = self.Propertys.Color3,
 		Enabled = true,
-		Destroy = false,
 	}
 
-	self.Retain(self, PropertyTable)
+	PropertyTable.Destroy = self.Retain(self, PropertyTable)
 
 	return PropertyTable
 end

--- a/src/CeiveImGizmo/init.lua
+++ b/src/CeiveImGizmo/init.lua
@@ -39,8 +39,13 @@ local Pool = {}
 
 local CleanerScheduled = false
 
-local function Retain(Gizmo, GizmoProperties)
-	table.insert(RetainObjects, { Gizmo, GizmoProperties })
+local function Retain(Gizmo, GizmoProperties): () -> ()
+	local Retained = { Gizmo, GizmoProperties }
+	RetainObjects[Retained] = true
+
+	return function()
+		RetainObjects[Retained] = nil
+	end
 end
 
 local function Register(object)
@@ -112,7 +117,7 @@ type IBox = {
 		AlwaysOnTop: boolean,
 		Transparency: number,
 		Enabled: boolean,
-		Destroy: boolean,
+		Destroy: () -> (),
 	},
 }
 
@@ -132,7 +137,7 @@ type IPlane = {
 		AlwaysOnTop: boolean,
 		Transparency: number,
 		Enabled: boolean,
-		Destroy: boolean,
+		Destroy: () -> (),
 	},
 }
 
@@ -151,7 +156,7 @@ type IWedge = {
 		AlwaysOnTop: boolean,
 		Transparency: number,
 		Enabled: boolean,
-		Destroy: boolean,
+		Destroy: () -> (),
 	},
 }
 
@@ -172,7 +177,7 @@ type ICircle = {
 		AlwaysOnTop: boolean,
 		Transparency: number,
 		Enabled: boolean,
-		Destroy: boolean,
+		Destroy: () -> (),
 	},
 }
 
@@ -193,7 +198,7 @@ type ISphere = {
 		AlwaysOnTop: boolean,
 		Transparency: number,
 		Enabled: boolean,
-		Destroy: boolean,
+		Destroy: () -> (),
 	},
 }
 
@@ -214,7 +219,7 @@ type ICylinder = {
 		AlwaysOnTop: boolean,
 		Transparency: number,
 		Enabled: boolean,
-		Destroy: boolean,
+		Destroy: () -> (),
 	},
 }
 
@@ -235,7 +240,7 @@ type ICapsule = {
 		AlwaysOnTop: boolean,
 		Transparency: number,
 		Enabled: boolean,
-		Destroy: boolean,
+		Destroy: () -> (),
 	},
 }
 
@@ -256,7 +261,7 @@ type ICone = {
 		AlwaysOnTop: boolean,
 		Transparency: number,
 		Enabled: boolean,
-		Destroy: boolean,
+		Destroy: () -> (),
 	},
 }
 
@@ -279,7 +284,7 @@ type IArrow = {
 		AlwaysOnTop: boolean,
 		Transparency: number,
 		Enabled: boolean,
-		Destroy: boolean,
+		Destroy: () -> (),
 	},
 }
 
@@ -300,7 +305,7 @@ type IMesh = {
 		AlwaysOnTop: boolean,
 		Transparency: number,
 		Enabled: boolean,
-		Destroy: boolean,
+		Destroy: () -> (),
 	},
 }
 
@@ -310,7 +315,7 @@ type ILine = {
 		self: ILine,
 		Transform: CFrame,
 		Length: number
-	) -> { Transform: CFrame, Length: number, Color3: Color3, AlwaysOnTop: boolean, Transparency: number, Enabled: boolean, Destroy: boolean },
+	) -> { Transform: CFrame, Length: number, Color3: Color3, AlwaysOnTop: boolean, Transparency: number, Enabled: boolean, Destroy: () -> () },
 }
 
 type IVolumeCone = {
@@ -328,7 +333,7 @@ type IVolumeCone = {
 		AlwaysOnTop: boolean,
 		Transparency: number,
 		Enabled: boolean,
-		Destroy: boolean,
+		Destroy: () -> (),
 	},
 }
 
@@ -338,7 +343,7 @@ type IVolumeBox = {
 		self: IVolumeBox,
 		Transform: CFrame,
 		Size: Vector3
-	) -> { Transform: CFrame, Size: Vector3, Color3: Color3, AlwaysOnTop: boolean, Transparency: number, Enabled: boolean, Destroy: boolean },
+	) -> { Transform: CFrame, Size: Vector3, Color3: Color3, AlwaysOnTop: boolean, Transparency: number, Enabled: boolean, Destroy: () -> () },
 }
 
 type IVolumeSphere = {
@@ -347,7 +352,7 @@ type IVolumeSphere = {
 		self: IVolumeSphere,
 		Transform: CFrame,
 		Radius: number
-	) -> { Transform: CFrame, Radius: number, Color3: Color3, AlwaysOnTop: boolean, Transparency: number, Enabled: boolean, Destroy: boolean },
+	) -> { Transform: CFrame, Radius: number, Color3: Color3, AlwaysOnTop: boolean, Transparency: number, Enabled: boolean, Destroy: () -> () },
 }
 
 type IVolumeCylinder = {
@@ -369,7 +374,7 @@ type IVolumeCylinder = {
 		AlwaysOnTop: boolean,
 		Transparency: number,
 		Enabled: boolean,
-		Destroy: boolean,
+		Destroy: () -> (),
 	},
 }
 
@@ -394,7 +399,7 @@ type IVolumeArrow = {
 		AlwaysOnTop: boolean,
 		Transparency: number,
 		Enabled: boolean,
-		Destroy: boolean,
+		Destroy: () -> (),
 	},
 }
 
@@ -620,15 +625,11 @@ function Ceive.Init()
 			DebrisCallback()
 		end
 
-		for i, Gizmo in RetainObjects do
+		for Gizmo in RetainObjects do
 			local GizmoPropertys = Gizmo[2]
 
 			if not GizmoPropertys.Enabled then
 				continue
-			end
-
-			if GizmoPropertys.Destroy then
-				table.remove(RetainObjects, i)
 			end
 
 			Gizmo[1]:Update(GizmoPropertys)


### PR DESCRIPTION
This is just a proposal, so feel free to close if this PR is not to your liking.

I noticed that the various `Gizmo:Create()` functions are destroyed by setting the returned table's `Destroy` property to `true`.

But this is inconsistent with how the Roblox API does this kind of thing. Usually we destroy instances by calling `instance:Destroy()` or disconnect signals by calling `connection:Disconnect()`.

So I think it would be good to use the same interface here as well.

PS: These changes are untested, so don't merge blindly please 😅